### PR TITLE
Fix mobile menu drawer behavior

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,7 +6,7 @@ import { Menu, Github, Languages, FileText, Shield } from 'lucide-react'
 import { FaDiscord } from 'react-icons/fa6'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Button } from '@/components/ui/button'
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Sheet, SheetClose, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { navLinks, siteConfig } from '@/lib/content'
 import { Logo } from '@/components/logo'
 import { scrollToSection } from '@/lib/utils'
@@ -143,34 +143,47 @@ export default function Header() {
                 <span className="sr-only">Toggle Menu</span>
               </Button>
             </SheetTrigger>
-            <SheetContent side="left">
-              <Link
-                href="/"
-                onClick={scrollToSection}
-                className="flex items-center space-x-2"
-              >
-                <Logo width={40} height={40} className="h-10 w-10" />
-                <span className="font-bold">{t('siteConfig.name')}</span>
-              </Link>
+            <SheetContent side="right">
+              <SheetClose asChild>
+                <Link
+                  href="/"
+                  onClick={scrollToSection}
+                  className="flex items-center space-x-2"
+                >
+                  <Logo width={40} height={40} className="h-10 w-10" />
+                  <span className="font-bold">{t('siteConfig.name')}</span>
+                </Link>
+              </SheetClose>
               <div className="mt-6 flex flex-col space-y-4">
                 {navLinks.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    onClick={scrollToSection}
-                    className="text-foreground/80"
-                  >
-                    {t(`navLinks.${link.key}`)}
-                  </Link>
+                  <SheetClose asChild key={link.href}>
+                    <Link
+                      href={link.href}
+                      onClick={scrollToSection}
+                      className="text-foreground/80"
+                    >
+                      {t(`navLinks.${link.key}`)}
+                    </Link>
+                  </SheetClose>
                 ))}
                 <div className="mt-4 border-t pt-4 flex flex-col space-y-4">
                   <span className="text-foreground/60">{t('legal.title')}</span>
-                  <Link href="/terms-of-service" className="text-foreground/80">
-                    {t('legal.terms')}
-                  </Link>
-                  <Link href="/privacy-policy" className="text-foreground/80">
-                    {t('legal.privacy')}
-                  </Link>
+                  <SheetClose asChild>
+                    <Link
+                      href="/terms-of-service"
+                      className="text-foreground/80"
+                    >
+                      {t('legal.terms')}
+                    </Link>
+                  </SheetClose>
+                  <SheetClose asChild>
+                    <Link
+                      href="/privacy-policy"
+                      className="text-foreground/80"
+                    >
+                      {t('legal.privacy')}
+                    </Link>
+                  </SheetClose>
                 </div>
               </div>
             </SheetContent>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,8 +47,11 @@ export function scrollToSection(event: ReactMouseEvent<HTMLAnchorElement>) {
           block: 'center',
         })
       } else {
-        // fallback: navigate as normal
-        window.location.hash = hash
+        const localeMatch = window.location.pathname.match(/^\/(en|zh)(?=\/|$)/)
+        const homePath = localeMatch ? `/${localeMatch[1]}` : '/'
+        const normalizedHomePath = homePath === '/' ? '' : homePath
+
+        window.location.href = `${normalizedHomePath}/#${hash.slice(1)}`
       }
     }
   }


### PR DESCRIPTION
## Summary
- switch the mobile header sheet to slide in from the right and close automatically when navigation links are selected
- update legal links in the mobile drawer to also close the sheet for consistent behavior
- improve the scroll helper so anchors missing on the current page redirect to the localized home section

## Testing
- npm run lint *(fails: existing jsx-a11y and @next/next lint findings in test files)*
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cb036bab688327a1b19d14d04784ce