### PR TITLE
docs: add docstrings and enforce jsdoc linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,30 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"]
+  "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["jsdoc"],
+  "settings": {
+    "jsdoc": {
+      "mode": "typescript"
+    }
+  },
+  "rules": {
+    "jsdoc/require-jsdoc": [
+      "error",
+      {
+        "publicOnly": false,
+        "contexts": [
+          "FunctionDeclaration",
+          "ClassDeclaration",
+          "MethodDefinition",
+          "VariableDeclaration[declarations.0.id.type='Identifier'] > ArrowFunctionExpression",
+          "ExportDefaultDeclaration > ArrowFunctionExpression"
+        ],
+        "require": {
+          "ArrowFunctionExpression": false,
+          "FunctionDeclaration": true,
+          "ClassDeclaration": true,
+          "MethodDefinition": true
+        }
+      }
+    ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "^9.35.0",
         "eslint-config-next": "^15.5.3",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-jsdoc": "^48.11.0",
         "jsdom": "^27.0.0",
         "postcss": "^8",
         "prettier": "^3.6.2",
@@ -612,6 +613,21 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
+      "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2038,6 +2054,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -4125,6 +4154,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4764,6 +4803,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -5591,6 +5640,32 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "48.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
+      "integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.46.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -7019,6 +7094,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsdom": {
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
@@ -7855,6 +7940,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-imports": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+      "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/parse5": {
@@ -8899,6 +8998,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8907,6 +9013,31 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -9335,6 +9466,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/synckit": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
+      "integrity": "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^9.35.0",
     "eslint-config-next": "^15.5.3",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jsdoc": "^48.11.0",
     "jsdom": "^27.0.0",
     "postcss": "^8",
     "prettier": "^3.6.2",

--- a/src/app/[locale]/layout.test.tsx
+++ b/src/app/[locale]/layout.test.tsx
@@ -48,57 +48,80 @@ import RootLayout, {
   viewport,
 } from '@/app/[locale]/layout'
 
+/**
+ * Resets hoisted spies and captured props before each test.
+ */
+function resetLayoutMocks() {
+  nextIntlProps.length = 0
+  themeProviderProps.length = 0
+  getMessagesMock.mockClear()
+  setRequestLocaleMock.mockClear()
+}
+
+/**
+ * Validates the exported metadata and viewport configuration.
+ */
+function exportsMetadataAndViewportConfiguration() {
+  expect(metadata.title).toBe('Vibe Engineers | Bring vibes into your code.')
+  expect(metadata.openGraph?.url).toBe('https://vibe-engineers.dev')
+  expect(viewport.themeColor).toEqual([
+    { media: '(prefers-color-scheme: light)', color: '#f5f5f5' },
+    { media: '(prefers-color-scheme: dark)', color: '#09090b' },
+  ])
+  expect(interMock).toHaveBeenCalledWith({ subsets: ['latin'], variable: '--font-inter' })
+}
+
+/**
+ * Ensures static params are generated for each supported locale.
+ */
+function generatesStaticParamsForTheSupportedLocales() {
+  expect(generateStaticParams()).toEqual([{ locale: 'en' }, { locale: 'zh' }])
+}
+
+/**
+ * Confirms the layout wraps children with translation and theme providers.
+ */
+async function wrapsTheAppWithInternationalizationAndThemingProviders() {
+  const result = await RootLayout({
+    children: <div data-testid="page-content">Content</div>,
+    params: Promise.resolve({ locale: 'en' }),
+  })
+
+  const markup = renderToStaticMarkup(result)
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(markup, 'text/html')
+
+  expect(setRequestLocaleMock).toHaveBeenCalledWith('en')
+  expect(getMessagesMock).toHaveBeenCalledWith({ locale: 'en' })
+
+  const html = doc.documentElement
+  expect(html.getAttribute('lang')).toBe('en')
+
+  const intlProvider = doc.querySelector('[data-testid="next-intl-provider"]')
+  expect(intlProvider).not.toBeNull()
+  expect(nextIntlProps[0]).toMatchObject({ locale: 'en', messages: { greeting: 'hello' } })
+
+  const themeProvider = doc.querySelector('[data-testid="theme-provider"]')
+  expect(themeProvider).not.toBeNull()
+  expect(themeProviderProps[0]).toMatchObject({
+    attribute: 'class',
+    defaultTheme: 'system',
+    enableSystem: true,
+  })
+
+  expect(doc.querySelector('[data-testid="page-content"]')).not.toBeNull()
+  expect(doc.querySelector('[data-testid="toaster"]')).not.toBeNull()
+}
+
 describe('Root layout', () => {
-  beforeEach(() => {
-    nextIntlProps.length = 0
-    themeProviderProps.length = 0
-    getMessagesMock.mockClear()
-    setRequestLocaleMock.mockClear()
-  })
+  beforeEach(resetLayoutMocks)
 
-  test('exports metadata and viewport configuration', () => {
-    expect(metadata.title).toBe('Vibe Engineers | Bring vibes into your code.')
-    expect(metadata.openGraph?.url).toBe('https://vibe-engineers.dev')
-    expect(viewport.themeColor).toEqual([
-      { media: '(prefers-color-scheme: light)', color: '#f5f5f5' },
-      { media: '(prefers-color-scheme: dark)', color: '#09090b' },
-    ])
-    expect(interMock).toHaveBeenCalledWith({ subsets: ['latin'], variable: '--font-inter' })
-  })
+  test('exports metadata and viewport configuration', exportsMetadataAndViewportConfiguration)
 
-  test('generates static params for the supported locales', () => {
-    expect(generateStaticParams()).toEqual([{ locale: 'en' }, { locale: 'zh' }])
-  })
+  test('generates static params for the supported locales', generatesStaticParamsForTheSupportedLocales)
 
-  test('wraps the app with internationalization and theming providers', async () => {
-    const result = await RootLayout({
-      children: <div data-testid="page-content">Content</div>,
-      params: Promise.resolve({ locale: 'en' }),
-    })
-
-    const markup = renderToStaticMarkup(result)
-    const parser = new DOMParser()
-    const doc = parser.parseFromString(markup, 'text/html')
-
-    expect(setRequestLocaleMock).toHaveBeenCalledWith('en')
-    expect(getMessagesMock).toHaveBeenCalledWith({ locale: 'en' })
-
-    const html = doc.documentElement
-    expect(html.getAttribute('lang')).toBe('en')
-
-    const intlProvider = doc.querySelector('[data-testid="next-intl-provider"]')
-    expect(intlProvider).not.toBeNull()
-    expect(nextIntlProps[0]).toMatchObject({ locale: 'en', messages: { greeting: 'hello' } })
-
-    const themeProvider = doc.querySelector('[data-testid="theme-provider"]')
-    expect(themeProvider).not.toBeNull()
-    expect(themeProviderProps[0]).toMatchObject({
-      attribute: 'class',
-      defaultTheme: 'system',
-      enableSystem: true,
-    })
-
-    expect(doc.querySelector('[data-testid="page-content"]')).not.toBeNull()
-    expect(doc.querySelector('[data-testid="toaster"]')).not.toBeNull()
-  })
+  test(
+    'wraps the app with internationalization and theming providers',
+    wrapsTheAppWithInternationalizationAndThemingProviders
+  )
 })

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -42,11 +42,21 @@ export const viewport: Viewport = {
   ],
 }
 
-// Add this function to tell Next.js which locales your app supports
+/**
+ * Informs Next.js about the locales that should be statically generated.
+ *
+ * @returns A list of locale parameter objects.
+ */
 export function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'zh' }] // Replace with your actual supported locales
 }
 
+/**
+ * Provides the shared HTML scaffold for all localized routes and wires up providers.
+ *
+ * @param props - The children to render and the promise resolving to locale params.
+ * @returns The rendered HTML document for the given locale.
+ */
 export default async function RootLayout({
   children,
   params,

--- a/src/app/[locale]/page.test.tsx
+++ b/src/app/[locale]/page.test.tsx
@@ -43,29 +43,44 @@ vi.mock('@/components/common/motion-section', () => ({
 
 import Home, { generateStaticParams } from '@/app/[locale]/page'
 
+/**
+ * Clears motion section spy state between tests.
+ */
+function resetMotionSectionSpy() {
+  motionSectionMock.mockClear()
+}
+
+/**
+ * Ensures static parameters are generated for each supported locale.
+ */
+function definesStaticParamsForSupportedLocales() {
+  expect(generateStaticParams()).toEqual([{ locale: 'en' }, { locale: 'zh' }])
+}
+
+/**
+ * Verifies the home page renders all major landing sections.
+ */
+function rendersAllLandingPageSections() {
+  render(<Home />)
+
+  expect(screen.getByTestId('header')).toBeInTheDocument()
+  expect(screen.getByTestId('footer')).toBeInTheDocument()
+
+  expect(screen.getByTestId('hero')).toBeInTheDocument()
+  expect(screen.getByTestId('tools-grid')).toBeInTheDocument()
+  expect(screen.getByTestId('philosophy')).toBeInTheDocument()
+  expect(screen.getByTestId('code-examples')).toBeInTheDocument()
+  expect(screen.getByTestId('faq')).toBeInTheDocument()
+  expect(screen.getByTestId('cta')).toBeInTheDocument()
+
+  expect(screen.getAllByTestId('motion-section')).toHaveLength(6)
+  expect(motionSectionMock).toHaveBeenCalledTimes(6)
+}
+
 describe('Home page', () => {
-  beforeEach(() => {
-    motionSectionMock.mockClear()
-  })
+  beforeEach(resetMotionSectionSpy)
 
-  test('defines static params for supported locales', () => {
-    expect(generateStaticParams()).toEqual([{ locale: 'en' }, { locale: 'zh' }])
-  })
+  test('defines static params for supported locales', definesStaticParamsForSupportedLocales)
 
-  test('renders all landing page sections', () => {
-    render(<Home />)
-
-    expect(screen.getByTestId('header')).toBeInTheDocument()
-    expect(screen.getByTestId('footer')).toBeInTheDocument()
-
-    expect(screen.getByTestId('hero')).toBeInTheDocument()
-    expect(screen.getByTestId('tools-grid')).toBeInTheDocument()
-    expect(screen.getByTestId('philosophy')).toBeInTheDocument()
-    expect(screen.getByTestId('code-examples')).toBeInTheDocument()
-    expect(screen.getByTestId('faq')).toBeInTheDocument()
-    expect(screen.getByTestId('cta')).toBeInTheDocument()
-
-    expect(screen.getAllByTestId('motion-section')).toHaveLength(6)
-    expect(motionSectionMock).toHaveBeenCalledTimes(6)
-  })
+  test('renders all landing page sections', rendersAllLandingPageSections)
 })

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,10 +8,20 @@ import FAQ from '@/components/landing/faq'
 import Footer from '@/components/common/footer'
 import MotionSection from '@/components/common/motion-section'
 
+/**
+ * Generates the static parameters for all supported locales.
+ *
+ * @returns A list of locale parameter objects for Next.js static generation.
+ */
 export function generateStaticParams() {
   return [{ locale: 'en' }, { locale: 'zh' }]
 }
 
+/**
+ * Renders the localized home page composed of the hero, product sections, and footer.
+ *
+ * @returns The complete landing page layout for a locale.
+ */
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center">

--- a/src/app/[locale]/privacy-policy/page.test.tsx
+++ b/src/app/[locale]/privacy-policy/page.test.tsx
@@ -50,23 +50,28 @@ vi.mock('@/components/common/motion-section', () => ({
 
 import PrivacyPage from '@/app/[locale]/privacy-policy/page'
 
-describe('Privacy Policy page', () => {
-  test('renders translated content sections', async () => {
-    const element = await PrivacyPage({ params: Promise.resolve({ locale: 'zh' }) })
-    const { container } = render(element)
+/**
+ * Ensures the privacy policy route fetches translations and renders the expected content.
+ */
+async function rendersTranslatedContentSections() {
+  const element = await PrivacyPage({ params: Promise.resolve({ locale: 'zh' }) })
+  const { container } = render(element)
 
-    expect(getTranslationsMock).toHaveBeenCalledWith({
-      locale: 'zh',
-      namespace: 'privacyPolicy',
-    })
-
-    expect(screen.getByRole('heading', { name: 'Privacy Policy', level: 1 })).toBeInTheDocument()
-    expect(screen.getAllByRole('heading', { level: 2 })[0]).toHaveTextContent('Data Collection')
-
-    const emailLink = container.querySelector('a[href="mailto:privacy@vibe.dev"]')
-    expect(emailLink).not.toBeNull()
-    expect(emailLink).toHaveTextContent('privacy@vibe.dev')
-
-    expect(screen.getByText('Updated on Sep 25, 2024')).toBeInTheDocument()
+  expect(getTranslationsMock).toHaveBeenCalledWith({
+    locale: 'zh',
+    namespace: 'privacyPolicy',
   })
+
+  expect(screen.getByRole('heading', { name: 'Privacy Policy', level: 1 })).toBeInTheDocument()
+  expect(screen.getAllByRole('heading', { level: 2 })[0]).toHaveTextContent('Data Collection')
+
+  const emailLink = container.querySelector('a[href="mailto:privacy@vibe.dev"]')
+  expect(emailLink).not.toBeNull()
+  expect(emailLink).toHaveTextContent('privacy@vibe.dev')
+
+  expect(screen.getByText('Updated on Sep 25, 2024')).toBeInTheDocument()
+}
+
+describe('Privacy Policy page', () => {
+  test('renders translated content sections', rendersTranslatedContentSections)
 })

--- a/src/app/[locale]/privacy-policy/page.tsx
+++ b/src/app/[locale]/privacy-policy/page.tsx
@@ -3,6 +3,12 @@ import Footer from '@/components/common/footer'
 import { getTranslations } from 'next-intl/server'
 import MotionSection from '@/components/common/motion-section'
 
+/**
+ * Renders the privacy policy page with localized content sections.
+ *
+ * @param props - The locale parameter promise provided by Next.js routing.
+ * @returns The privacy policy layout for the requested locale.
+ */
 export default async function PrivacyPage({
   params,
 }: {

--- a/src/app/[locale]/team/page.test.tsx
+++ b/src/app/[locale]/team/page.test.tsx
@@ -39,24 +39,29 @@ vi.mock('@/components/team/team-page', () => ({
 
 import TeamPageRoute from '@/app/[locale]/team/page'
 
-describe('Team page route', () => {
-  test('fetches translations and renders the team page', async () => {
-    teamPageProps.length = 0
-    const element = await TeamPageRoute({ params: Promise.resolve({ locale: 'zh' }) })
-    render(element)
+/**
+ * Confirms the team route loads translations and renders the page component.
+ */
+async function fetchesTranslationsAndRendersTheTeamPage() {
+  teamPageProps.length = 0
+  const element = await TeamPageRoute({ params: Promise.resolve({ locale: 'zh' }) })
+  render(element)
 
-    expect(getTranslationsMock).toHaveBeenCalledWith({
-      locale: 'zh',
-      namespace: 'teamPage',
-    })
-
-    expect(screen.getByTestId('header')).toBeInTheDocument()
-    expect(screen.getByTestId('footer')).toBeInTheDocument()
-    expect(screen.getByTestId('team-page')).toBeInTheDocument()
-
-    expect(teamPageProps[0]).toMatchObject({
-      title: 'Meet the Team',
-      subtitle: 'People behind the vibes',
-    })
+  expect(getTranslationsMock).toHaveBeenCalledWith({
+    locale: 'zh',
+    namespace: 'teamPage',
   })
+
+  expect(screen.getByTestId('header')).toBeInTheDocument()
+  expect(screen.getByTestId('footer')).toBeInTheDocument()
+  expect(screen.getByTestId('team-page')).toBeInTheDocument()
+
+  expect(teamPageProps[0]).toMatchObject({
+    title: 'Meet the Team',
+    subtitle: 'People behind the vibes',
+  })
+}
+
+describe('Team page route', () => {
+  test('fetches translations and renders the team page', fetchesTranslationsAndRendersTheTeamPage)
 })

--- a/src/app/[locale]/team/page.tsx
+++ b/src/app/[locale]/team/page.tsx
@@ -3,6 +3,12 @@ import Footer from '@/components/common/footer'
 import TeamPage from '@/components/team/team-page'
 import { getTranslations } from 'next-intl/server'
 
+/**
+ * Renders the localized team page with translated headings.
+ *
+ * @param props - The locale parameter promise supplied by Next.js routing.
+ * @returns The team page layout for the requested locale.
+ */
 export default async function Team({
   params,
 }: {

--- a/src/app/[locale]/terms-of-service/page.test.tsx
+++ b/src/app/[locale]/terms-of-service/page.test.tsx
@@ -50,28 +50,33 @@ vi.mock('@/components/common/motion-section', () => ({
 
 import TermsPage from '@/app/[locale]/terms-of-service/page'
 
-describe('Terms of Service page', () => {
-  test('renders translated sections and metadata', async () => {
-    const element = await TermsPage({ params: Promise.resolve({ locale: 'en' }) })
-    const { container } = render(element)
+/**
+ * Verifies the terms of service route renders localized content and metadata.
+ */
+async function rendersTranslatedSectionsAndMetadata() {
+  const element = await TermsPage({ params: Promise.resolve({ locale: 'en' }) })
+  const { container } = render(element)
 
-    expect(getTranslationsMock).toHaveBeenCalledWith({
-      locale: 'en',
-      namespace: 'termsOfService',
-    })
-
-    expect(screen.getByTestId('header')).toBeInTheDocument()
-    expect(screen.getByTestId('footer')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'Terms of Service', level: 1 })).toBeInTheDocument()
-
-    const sectionHeadings = screen.getAllByRole('heading', { level: 2 })
-    expect(sectionHeadings).toHaveLength(1)
-    expect(sectionHeadings[0]).toHaveTextContent('Section One')
-
-    const emailLink = container.querySelector('a[href="mailto:legal@vibe.dev"]')
-    expect(emailLink).not.toBeNull()
-    expect(emailLink).toHaveTextContent('legal@vibe.dev')
-
-    expect(screen.getByText('Last updated on Oct 1, 2024')).toBeInTheDocument()
+  expect(getTranslationsMock).toHaveBeenCalledWith({
+    locale: 'en',
+    namespace: 'termsOfService',
   })
+
+  expect(screen.getByTestId('header')).toBeInTheDocument()
+  expect(screen.getByTestId('footer')).toBeInTheDocument()
+  expect(screen.getByRole('heading', { name: 'Terms of Service', level: 1 })).toBeInTheDocument()
+
+  const sectionHeadings = screen.getAllByRole('heading', { level: 2 })
+  expect(sectionHeadings).toHaveLength(1)
+  expect(sectionHeadings[0]).toHaveTextContent('Section One')
+
+  const emailLink = container.querySelector('a[href="mailto:legal@vibe.dev"]')
+  expect(emailLink).not.toBeNull()
+  expect(emailLink).toHaveTextContent('legal@vibe.dev')
+
+  expect(screen.getByText('Last updated on Oct 1, 2024')).toBeInTheDocument()
+}
+
+describe('Terms of Service page', () => {
+  test('renders translated sections and metadata', rendersTranslatedSectionsAndMetadata)
 })

--- a/src/app/[locale]/terms-of-service/page.tsx
+++ b/src/app/[locale]/terms-of-service/page.tsx
@@ -3,6 +3,12 @@ import Footer from '@/components/common/footer'
 import { getTranslations } from 'next-intl/server'
 import MotionSection from '@/components/common/motion-section'
 
+/**
+ * Renders the localized terms of service page with structured content sections.
+ *
+ * @param props - The locale parameter promise supplied by Next.js routing.
+ * @returns The terms of service layout for the requested locale.
+ */
 export default async function TermsPage({
   params,
 }: {

--- a/src/components/common/footer.test.tsx
+++ b/src/components/common/footer.test.tsx
@@ -32,55 +32,73 @@ vi.mock('@/lib/utils', async () => {
   }
 })
 
+/**
+ * Clears the scroll handler mock so each test starts cleanly.
+ */
+function resetScrollToSectionMock() {
+  scrollToSectionMock.mockClear()
+}
+
+/**
+ * Validates that the footer renders its navigation sections and social links.
+ */
+function rendersNavigationSectionsAndSocialLinks() {
+  render(<Footer />)
+
+  expect(screen.getByTestId('themed-logo')).toBeInTheDocument()
+
+  const aboutSection = screen.getByRole('heading', { name: 'footer.nav.about.title' })
+  const contributeSection = screen.getByRole('heading', {
+    name: 'footer.nav.contribute.title',
+  })
+  const legalSection = screen.getByRole('heading', { name: 'footer.nav.legal.title' })
+
+  expect(aboutSection).toBeInTheDocument()
+  expect(contributeSection).toBeInTheDocument()
+  expect(legalSection).toBeInTheDocument()
+
+  const aboutLinks = within(aboutSection.parentElement as HTMLElement).getAllByRole(
+    'link'
+  )
+  expect(aboutLinks.map((link) => link.getAttribute('href'))).toEqual([
+    '/team',
+    'https://github.com/sponsors/vibe-engineers',
+  ])
+
+  expect(
+    screen.getByRole('link', { name: 'footer.nav.contribute.links.sponsor' })
+  ).toHaveAttribute('href', 'https://github.com/sponsors/vibe-engineers')
+  expect(
+    screen.getByRole('link', { name: 'footer.nav.legal.links.privacy' })
+  ).toHaveAttribute('href', '/privacy-policy')
+
+  expect(screen.getByLabelText('GitHub')).toBeInTheDocument()
+  expect(screen.getByLabelText('Discord')).toBeInTheDocument()
+
+  const year = new Date().getFullYear()
+  expect(screen.getByText(`© ${year} siteConfig.name. footer.rights`)).toBeInTheDocument()
+}
+
+/**
+ * Ensures the footer brand link triggers the smooth scroll helper.
+ */
+function invokesScrollToSectionWhenBrandLinkIsClicked() {
+  render(<Footer />)
+
+  const brandLink = screen.getByRole('link', { name: /siteConfig.name/ })
+
+  fireEvent.click(brandLink)
+
+  expect(scrollToSectionMock).toHaveBeenCalledTimes(1)
+}
+
 describe('Footer', () => {
-  beforeEach(() => {
-    scrollToSectionMock.mockClear()
-  })
+  beforeEach(resetScrollToSectionMock)
 
-  test('renders navigation sections and social links', () => {
-    render(<Footer />)
+  test('renders navigation sections and social links', rendersNavigationSectionsAndSocialLinks)
 
-    expect(screen.getByTestId('themed-logo')).toBeInTheDocument()
-
-    const aboutSection = screen.getByRole('heading', { name: 'footer.nav.about.title' })
-    const contributeSection = screen.getByRole('heading', {
-      name: 'footer.nav.contribute.title',
-    })
-    const legalSection = screen.getByRole('heading', { name: 'footer.nav.legal.title' })
-
-    expect(aboutSection).toBeInTheDocument()
-    expect(contributeSection).toBeInTheDocument()
-    expect(legalSection).toBeInTheDocument()
-
-    const aboutLinks = within(aboutSection.parentElement as HTMLElement).getAllByRole(
-      'link'
-    )
-    expect(aboutLinks.map((link) => link.getAttribute('href'))).toEqual([
-      '/team',
-      'https://github.com/sponsors/vibe-engineers',
-    ])
-
-    expect(
-      screen.getByRole('link', { name: 'footer.nav.contribute.links.sponsor' })
-    ).toHaveAttribute('href', 'https://github.com/sponsors/vibe-engineers')
-    expect(
-      screen.getByRole('link', { name: 'footer.nav.legal.links.privacy' })
-    ).toHaveAttribute('href', '/privacy-policy')
-
-    expect(screen.getByLabelText('GitHub')).toBeInTheDocument()
-    expect(screen.getByLabelText('Discord')).toBeInTheDocument()
-
-    const year = new Date().getFullYear()
-    expect(screen.getByText(`© ${year} siteConfig.name. footer.rights`)).toBeInTheDocument()
-  })
-
-  test('invokes scrollToSection when brand link is clicked', () => {
-    render(<Footer />)
-
-    const brandLink = screen.getByRole('link', { name: /siteConfig.name/ })
-
-    fireEvent.click(brandLink)
-
-    expect(scrollToSectionMock).toHaveBeenCalledTimes(1)
-  })
+  test(
+    'invokes scrollToSection when brand link is clicked',
+    invokesScrollToSectionWhenBrandLinkIsClicked
+  )
 })

--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -32,6 +32,11 @@ const footerNav = {
   },
 }
 
+/**
+ * Renders the global footer with navigation links, social buttons, and branding.
+ *
+ * @returns The footer element for the site.
+ */
 export default function Footer() {
   const t = useTranslations()
 

--- a/src/components/common/header.test.tsx
+++ b/src/components/common/header.test.tsx
@@ -4,9 +4,9 @@ import { expect, test, vi } from 'vitest'
 import Header from '@/components/common/header'
 
 vi.mock('next/image', () => ({
-  default: (props: any) => {
+  default: ({ alt = '', ...rest }: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />
+    return <img alt={alt} {...rest} />
   },
 }))
 
@@ -33,7 +33,10 @@ vi.mock('@/hooks/use-toast', () => ({
   }),
 }))
 
-test('renders header with navigation and theme toggle', () => {
+/**
+ * Ensures the header renders navigation links and social actions.
+ */
+function rendersHeaderWithNavigationAndThemeToggle() {
   render(<Header />)
 
   expect(screen.getByAltText('Vibe Engineers Logo')).toBeInTheDocument()
@@ -45,4 +48,9 @@ test('renders header with navigation and theme toggle', () => {
   expect(screen.getByLabelText('Discord')).toBeInTheDocument()
   // The theme toggle button does not have a name, so we can't search it by name
   // expect(screen.getByRole('button', { name: 'Toggle theme' })).toBeInTheDocument()
-})
+}
+
+test(
+  'renders header with navigation and theme toggle',
+  rendersHeaderWithNavigationAndThemeToggle
+)

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -25,6 +25,11 @@ import {
 } from '@/components/common/ui/accordion'
 import { useToast } from '@/hooks/use-toast'
 
+/**
+ * Displays the site header with navigation, language selection, and theming controls.
+ *
+ * @returns The sticky header element rendered at the top of the viewport.
+ */
 export default function Header() {
   const t = useTranslations()
   const locale = useLocale()
@@ -43,6 +48,11 @@ export default function Header() {
     { locale: 'zh', label: t('language.zh'), icon: '🇨🇳' },
   ]
 
+  /**
+   * Shows toast feedback when a user chooses a different language.
+   *
+   * @param lang - The selected language option.
+   */
   function handleLanguageSwitch(lang: (typeof languageOptions)[number]) {
     toast({
       title: t('language.toast.title'),
@@ -50,6 +60,11 @@ export default function Header() {
     })
   }
 
+  /**
+   * Handles closing the mobile menu after navigating to a section.
+   *
+   * @param event - The anchor click event triggered from the sheet menu.
+   */
   function handleMobileNavigationClick(
     event: ReactMouseEvent<HTMLAnchorElement>,
   ) {

--- a/src/components/common/logo.test.tsx
+++ b/src/components/common/logo.test.tsx
@@ -4,9 +4,9 @@ import { expect, test, vi } from 'vitest'
 import { ThemedLogo } from '@/components/common/themed-logo'
 
 vi.mock('next/image', () => ({
-  default: (props: any) => {
+  default: ({ alt = '', ...rest }: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />
+    return <img alt={alt} {...rest} />
   },
 }))
 
@@ -16,7 +16,10 @@ vi.mock('next-themes', () => ({
   }),
 }))
 
-test('renders light theme logo by default', () => {
+/**
+ * Ensures the light logo renders when the theme is resolved to light.
+ */
+function rendersLightThemeLogoByDefault() {
   render(
     <ThemedLogo
       darkSrc="/images/dark-theme-logo.webp"
@@ -27,4 +30,6 @@ test('renders light theme logo by default', () => {
 
   const logo = screen.getByAltText('Vibe Engineers Logo')
   expect(logo).toHaveAttribute('src', '/images/light-theme-logo.webp')
-})
+}
+
+test('renders light theme logo by default', rendersLightThemeLogoByDefault)

--- a/src/components/common/motion-section.test.tsx
+++ b/src/components/common/motion-section.test.tsx
@@ -20,6 +20,7 @@ vi.mock('framer-motion', () => {
       )
     }
   )
+  MotionSectionComponent.displayName = 'MotionSectionComponentMock'
 
   return {
     motion: {
@@ -29,48 +30,66 @@ vi.mock('framer-motion', () => {
   }
 })
 
+/**
+ * Resets spies to ensure tests do not leak state.
+ */
+function resetMotionSectionMocks() {
+  useInViewMock.mockReset()
+  motionSectionPropsMock.mockClear()
+}
+
+/**
+ * Verifies the motion section animates when the element becomes visible.
+ */
+function animatesIntoViewWhenTheSectionBecomesVisible() {
+  useInViewMock.mockReturnValue(true)
+
+  render(
+    <MotionSection delay={0.3} id="features">
+      <p>Content</p>
+    </MotionSection>
+  )
+
+  expect(useInViewMock).toHaveBeenCalledWith(expect.any(Object), { once: true })
+
+  expect(motionSectionPropsMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'features',
+      initial: { opacity: 0, y: 20 },
+      animate: { opacity: 1, y: 0 },
+      transition: { duration: 0.5, delay: 0.3 },
+    })
+  )
+
+  expect(screen.getByTestId('motion-section')).toBeInTheDocument()
+}
+
+/**
+ * Confirms the section stays hidden until it is in view.
+ */
+function keepsTheSectionHiddenUntilItIsInView() {
+  useInViewMock.mockReturnValue(false)
+
+  render(
+    <MotionSection>
+      <p>Hidden content</p>
+    </MotionSection>
+  )
+
+  expect(motionSectionPropsMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      animate: { opacity: 0, y: 20 },
+    })
+  )
+}
+
 describe('MotionSection', () => {
-  beforeEach(() => {
-    useInViewMock.mockReset()
-    motionSectionPropsMock.mockClear()
-  })
+  beforeEach(resetMotionSectionMocks)
 
-  test('animates into view when the section becomes visible', () => {
-    useInViewMock.mockReturnValue(true)
+  test(
+    'animates into view when the section becomes visible',
+    animatesIntoViewWhenTheSectionBecomesVisible
+  )
 
-    render(
-      <MotionSection delay={0.3} id="features">
-        <p>Content</p>
-      </MotionSection>
-    )
-
-    expect(useInViewMock).toHaveBeenCalledWith(expect.any(Object), { once: true })
-
-    expect(motionSectionPropsMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 'features',
-        initial: { opacity: 0, y: 20 },
-        animate: { opacity: 1, y: 0 },
-        transition: { duration: 0.5, delay: 0.3 },
-      })
-    )
-
-    expect(screen.getByTestId('motion-section')).toBeInTheDocument()
-  })
-
-  test('keeps the section hidden until it is in view', () => {
-    useInViewMock.mockReturnValue(false)
-
-    render(
-      <MotionSection>
-        <p>Hidden content</p>
-      </MotionSection>
-    )
-
-    expect(motionSectionPropsMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        animate: { opacity: 0, y: 20 },
-      })
-    )
-  })
+  test('keeps the section hidden until it is in view', keepsTheSectionHiddenUntilItIsInView)
 })

--- a/src/components/common/motion-section.tsx
+++ b/src/components/common/motion-section.tsx
@@ -9,6 +9,12 @@ interface MotionSectionProps {
   id?: string
 }
 
+/**
+ * Animates content into view with a fade and slide effect once it enters the viewport.
+ *
+ * @param props - The section configuration including children, delay, and optional id.
+ * @returns An animated motion section element.
+ */
 const MotionSection: FC<MotionSectionProps> = ({
   children,
   delay = 0.15,

--- a/src/components/common/theme-provider.test.tsx
+++ b/src/components/common/theme-provider.test.tsx
@@ -9,7 +9,10 @@ vi.mock('next-themes', () => ({
   ),
 }))
 
-test('renders children', () => {
+/**
+ * Verifies that the wrapper renders its child elements.
+ */
+function rendersChildren() {
   render(
     <ThemeProvider>
       <div>Child</div>
@@ -18,4 +21,6 @@ test('renders children', () => {
 
   expect(screen.getByTestId('next-themes-provider')).toBeInTheDocument()
   expect(screen.getByText('Child')).toBeInTheDocument()
-})
+}
+
+test('renders children', rendersChildren)

--- a/src/components/common/theme-provider.tsx
+++ b/src/components/common/theme-provider.tsx
@@ -4,6 +4,12 @@ import * as React from 'react'
 import { type ThemeProviderProps } from 'next-themes/dist/types'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 
+/**
+ * Wraps the NextThemes provider to expose theme context to client components.
+ *
+ * @param props - The theme provider props including the child nodes to render.
+ * @returns The themed provider element.
+ */
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/src/components/common/theme-toggle.test.tsx
+++ b/src/components/common/theme-toggle.test.tsx
@@ -12,15 +12,25 @@ vi.mock('next-themes', () => ({
   }),
 }))
 
-test('renders toggle button', () => {
+/**
+ * Validates that the toggle renders with an accessible button.
+ */
+function rendersToggleButton() {
   render(<ThemeToggle />)
   expect(
     screen.getByRole('button', { name: 'Toggle theme' })
   ).toBeInTheDocument()
-})
+}
 
-test('calls setTheme on click', () => {
+/**
+ * Confirms the toggle invokes the setTheme callback.
+ */
+function callsSetThemeOnClick() {
   render(<ThemeToggle />)
   fireEvent.click(screen.getByRole('button', { name: 'Toggle theme' }))
   expect(mockSetTheme).toHaveBeenCalledWith('dark')
-})
+}
+
+test('renders toggle button', rendersToggleButton)
+
+test('calls setTheme on click', callsSetThemeOnClick)

--- a/src/components/common/theme-toggle.tsx
+++ b/src/components/common/theme-toggle.tsx
@@ -6,9 +6,17 @@ import { useTheme } from 'next-themes'
 
 import { Button } from '@/components/common/ui/button'
 
+/**
+ * Renders a button that toggles between the light and dark themes.
+ *
+ * @returns The theme toggle icon button.
+ */
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
 
+  /**
+   * Switches the active theme between light and dark modes.
+   */
   const toggleTheme = () => {
     setTheme(theme === 'light' ? 'dark' : 'light')
   }

--- a/src/components/common/themed-logo.tsx
+++ b/src/components/common/themed-logo.tsx
@@ -9,6 +9,12 @@ type LogoProps = Omit<ImageProps, 'src'> & {
   lightSrc?: string
 }
 
+/**
+ * Chooses between light and dark logo sources based on the resolved theme.
+ *
+ * @param props - The logo image props including theme-specific sources.
+ * @returns A Next.js image element for the appropriate theme.
+ */
 export function ThemedLogo({ darkSrc, lightSrc, alt, ...props }: LogoProps) {
   const { resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)

--- a/src/components/common/ui/accordion.tsx
+++ b/src/components/common/ui/accordion.tsx
@@ -6,8 +6,14 @@ import { ChevronDown } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Root accordion component styled with shared Tailwind utilities.
+ */
 const Accordion = AccordionPrimitive.Root
 
+/**
+ * Accordion item that applies border styling and forwards its ref.
+ */
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
@@ -20,6 +26,9 @@ const AccordionItem = React.forwardRef<
 ))
 AccordionItem.displayName = 'AccordionItem'
 
+/**
+ * Accordion trigger that renders a rotating chevron indicator.
+ */
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
@@ -40,6 +49,9 @@ const AccordionTrigger = React.forwardRef<
 ))
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
 
+/**
+ * Accordion content region that animates its open and closed states.
+ */
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>

--- a/src/components/common/ui/alert.tsx
+++ b/src/components/common/ui/alert.tsx
@@ -3,6 +3,9 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Variant definitions for the alert component, controlling base styling and destructive state.
+ */
 const alertVariants = cva(
   'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
   {
@@ -19,6 +22,9 @@ const alertVariants = cva(
   }
 )
 
+/**
+ * Alert container that forwards refs and applies visual variants.
+ */
 const Alert = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
@@ -32,6 +38,9 @@ const Alert = React.forwardRef<
 ))
 Alert.displayName = 'Alert'
 
+/**
+ * Styled heading element displayed at the top of an alert.
+ */
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
@@ -44,6 +53,9 @@ const AlertTitle = React.forwardRef<
 ))
 AlertTitle.displayName = 'AlertTitle'
 
+/**
+ * Text wrapper that provides spacing and typography for alert content.
+ */
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>

--- a/src/components/common/ui/button.test.tsx
+++ b/src/components/common/ui/button.test.tsx
@@ -3,16 +3,29 @@ import { expect, test } from 'vitest'
 
 import { Button } from '@/components/common/ui/button'
 
-test('renders button with correct text', () => {
+/**
+ * Confirms the button renders with its provided text content.
+ */
+function rendersButtonWithCorrectText() {
   render(<Button>Click me</Button>)
   expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
-})
+}
 
-test('renders as a child component when asChild is true', () => {
+/**
+ * Ensures the button renders its child component when using the asChild prop.
+ */
+function rendersAsAChildComponentWhenAsChildIsTrue() {
   render(
     <Button asChild>
-      <a href="/">Link</a>
+      <a href="https://example.com">Link</a>
     </Button>
   )
   expect(screen.getByRole('link', { name: 'Link' })).toBeInTheDocument()
-})
+}
+
+test('renders button with correct text', rendersButtonWithCorrectText)
+
+test(
+  'renders as a child component when asChild is true',
+  rendersAsAChildComponentWhenAsChildIsTrue
+)

--- a/src/components/common/ui/button.tsx
+++ b/src/components/common/ui/button.tsx
@@ -4,6 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Variant definitions that control the appearance and sizing of the shared button component.
+ */
 const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
@@ -33,12 +36,18 @@ const buttonVariants = cva(
   }
 )
 
+/**
+ * Props accepted by the shared button component, including variant and sizing options.
+ */
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }
 
+/**
+ * Polymorphic button that supports Radix's Slot for custom rendering and shared styling variants.
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button'

--- a/src/components/common/ui/card.tsx
+++ b/src/components/common/ui/card.tsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Card container that adds border, background, and shadow styling.
+ */
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -17,6 +20,9 @@ const Card = React.forwardRef<
 ))
 Card.displayName = 'Card'
 
+/**
+ * Header region of a card that provides padding and vertical spacing.
+ */
 const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -29,6 +35,9 @@ const CardHeader = React.forwardRef<
 ))
 CardHeader.displayName = 'CardHeader'
 
+/**
+ * Title wrapper styled for prominent typography within a card.
+ */
 const CardTitle = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -44,6 +53,9 @@ const CardTitle = React.forwardRef<
 ))
 CardTitle.displayName = 'CardTitle'
 
+/**
+ * Description text element used underneath card titles.
+ */
 const CardDescription = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -56,6 +68,9 @@ const CardDescription = React.forwardRef<
 ))
 CardDescription.displayName = 'CardDescription'
 
+/**
+ * Main content area of the card with optional padding adjustments.
+ */
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -64,6 +79,9 @@ const CardContent = React.forwardRef<
 ))
 CardContent.displayName = 'CardContent'
 
+/**
+ * Footer section of the card that aligns items horizontally.
+ */
 const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>

--- a/src/components/common/ui/dropdown-menu.tsx
+++ b/src/components/common/ui/dropdown-menu.tsx
@@ -6,18 +6,39 @@ import { Check, ChevronRight, Circle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Root dropdown menu component that controls menu state.
+ */
 const DropdownMenu = DropdownMenuPrimitive.Root
 
+/**
+ * Trigger element that opens or closes the dropdown menu.
+ */
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 
+/**
+ * Groups related dropdown menu items together.
+ */
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
 
+/**
+ * Portal used to render dropdown content outside of the DOM hierarchy.
+ */
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal
 
+/**
+ * Sub-menu container for nested dropdown items.
+ */
 const DropdownMenuSub = DropdownMenuPrimitive.Sub
 
+/**
+ * Radio group container for mutually exclusive dropdown selections.
+ */
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
+/**
+ * Trigger element for nested sub-menus within the dropdown.
+ */
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
@@ -40,6 +61,9 @@ const DropdownMenuSubTrigger = React.forwardRef<
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
 
+/**
+ * Content container rendered for dropdown sub-menus.
+ */
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
@@ -56,6 +80,9 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
+/**
+ * Main dropdown content surface rendered inside a portal.
+ */
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -74,6 +101,9 @@ const DropdownMenuContent = React.forwardRef<
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
+/**
+ * Standard dropdown menu item that supports optional indentation.
+ */
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
@@ -92,6 +122,9 @@ const DropdownMenuItem = React.forwardRef<
 ))
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
+/**
+ * Checkbox-style dropdown item that reflects a boolean selection state.
+ */
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
@@ -116,6 +149,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
 
+/**
+ * Radio-style dropdown item that participates in mutual exclusion within a radio group.
+ */
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
@@ -138,6 +174,9 @@ const DropdownMenuRadioItem = React.forwardRef<
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
+/**
+ * Non-interactive label used to separate groups of dropdown items.
+ */
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
@@ -156,6 +195,9 @@ const DropdownMenuLabel = React.forwardRef<
 ))
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
+/**
+ * Visual separator that divides dropdown menu sections.
+ */
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
@@ -168,6 +210,9 @@ const DropdownMenuSeparator = React.forwardRef<
 ))
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
 
+/**
+ * Displays keyboard shortcut hints aligned to the end of menu items.
+ */
 const DropdownMenuShortcut = ({
   className,
   ...props

--- a/src/components/common/ui/sheet.tsx
+++ b/src/components/common/ui/sheet.tsx
@@ -7,14 +7,29 @@ import { X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Root sheet component controlling dialog state.
+ */
 const Sheet = SheetPrimitive.Root
 
+/**
+ * Element used to open the sheet dialog.
+ */
 const SheetTrigger = SheetPrimitive.Trigger
 
+/**
+ * Element that closes the sheet dialog when activated.
+ */
 const SheetClose = SheetPrimitive.Close
 
+/**
+ * Portal target where sheet content is rendered.
+ */
 const SheetPortal = SheetPrimitive.Portal
 
+/**
+ * Semi-transparent overlay displayed behind the sheet dialog.
+ */
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
@@ -30,6 +45,9 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
+/**
+ * Configures positional variants that determine how the sheet animates into view.
+ */
 const sheetVariants = cva(
   'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
@@ -49,10 +67,16 @@ const sheetVariants = cva(
   }
 )
 
+/**
+ * Props supported by the sheet content component including placement variants.
+ */
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
+/**
+ * Sheet content container that renders the dialog body with animations.
+ */
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
@@ -74,6 +98,9 @@ const SheetContent = React.forwardRef<
 ))
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
+/**
+ * Wrapper for header content within a sheet dialog.
+ */
 const SheetHeader = ({
   className,
   ...props
@@ -88,6 +115,9 @@ const SheetHeader = ({
 )
 SheetHeader.displayName = 'SheetHeader'
 
+/**
+ * Wrapper that aligns footer actions within the sheet dialog.
+ */
 const SheetFooter = ({
   className,
   ...props
@@ -102,6 +132,9 @@ const SheetFooter = ({
 )
 SheetFooter.displayName = 'SheetFooter'
 
+/**
+ * Styled title element for sheet dialogs.
+ */
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
@@ -114,6 +147,9 @@ const SheetTitle = React.forwardRef<
 ))
 SheetTitle.displayName = SheetPrimitive.Title.displayName
 
+/**
+ * Description text element providing additional context for the sheet.
+ */
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>

--- a/src/components/common/ui/tabs.tsx
+++ b/src/components/common/ui/tabs.tsx
@@ -5,8 +5,14 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Root tabs component that manages tab state.
+ */
 const Tabs = TabsPrimitive.Root
 
+/**
+ * Container for tab triggers rendered with shared styling.
+ */
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
@@ -22,6 +28,9 @@ const TabsList = React.forwardRef<
 ))
 TabsList.displayName = TabsPrimitive.List.displayName
 
+/**
+ * Individual tab trigger that changes the active tab when selected.
+ */
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
@@ -37,6 +46,9 @@ const TabsTrigger = React.forwardRef<
 ))
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
+/**
+ * Panel that displays the content associated with a selected tab.
+ */
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>

--- a/src/components/common/ui/toast.tsx
+++ b/src/components/common/ui/toast.tsx
@@ -7,8 +7,14 @@ import { X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Provider that enables toast notifications within its subtree.
+ */
 const ToastProvider = ToastPrimitives.Provider
 
+/**
+ * Viewport that positions toast notifications on the screen.
+ */
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
@@ -24,6 +30,9 @@ const ToastViewport = React.forwardRef<
 ))
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
+/**
+ * Variant definitions for toast notifications supporting default and destructive styles.
+ */
 const toastVariants = cva(
   'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
@@ -40,6 +49,9 @@ const toastVariants = cva(
   }
 )
 
+/**
+ * Styled toast container that accepts variant-specific props.
+ */
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
@@ -55,6 +67,9 @@ const Toast = React.forwardRef<
 })
 Toast.displayName = ToastPrimitives.Root.displayName
 
+/**
+ * Button-like element rendered inside a toast for user actions.
+ */
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
@@ -70,6 +85,9 @@ const ToastAction = React.forwardRef<
 ))
 ToastAction.displayName = ToastPrimitives.Action.displayName
 
+/**
+ * Icon button that dismisses an individual toast.
+ */
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
@@ -88,6 +106,9 @@ const ToastClose = React.forwardRef<
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName
 
+/**
+ * Typography wrapper for toast titles.
+ */
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
@@ -100,6 +121,9 @@ const ToastTitle = React.forwardRef<
 ))
 ToastTitle.displayName = ToastPrimitives.Title.displayName
 
+/**
+ * Text wrapper for toast descriptions.
+ */
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
@@ -112,8 +136,14 @@ const ToastDescription = React.forwardRef<
 ))
 ToastDescription.displayName = ToastPrimitives.Description.displayName
 
+/**
+ * Props supported by the toast component.
+ */
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
 
+/**
+ * Represents a rendered toast action element.
+ */
 type ToastActionElement = React.ReactElement<typeof ToastAction>
 
 export {

--- a/src/components/common/ui/toaster.tsx
+++ b/src/components/common/ui/toaster.tsx
@@ -10,6 +10,11 @@ import {
   ToastViewport,
 } from '@/components/common/ui/toast'
 
+/**
+ * Renders the toast provider and displays queued toast notifications.
+ *
+ * @returns The toaster component responsible for rendering toast messages.
+ */
 export function Toaster() {
   const { toasts } = useToast()
 

--- a/src/components/landing/call-to-action.test.tsx
+++ b/src/components/landing/call-to-action.test.tsx
@@ -9,9 +9,9 @@ vi.mock('next-intl', () => ({
 }))
 
 vi.mock('next/image', () => ({
-  default: (props: any) => {
+  default: ({ alt = '', ...rest }: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />
+    return <img alt={alt} {...rest} />
   },
 }))
 
@@ -19,7 +19,10 @@ vi.mock('@/navigation', () => ({
   Link: (props: any) => <a {...props} />,
 }))
 
-test('renders call to action with title, subcopy, and buttons', () => {
+/**
+ * Checks that the call-to-action renders translated messaging and buttons.
+ */
+function rendersCallToActionWithTitleSubcopyAndButtons() {
   render(<CallToAction />)
 
   expect(screen.getByText('callToAction.title')).toBeInTheDocument()
@@ -28,4 +31,9 @@ test('renders call to action with title, subcopy, and buttons', () => {
   expect(screen.getByText('hero.secondaryCta')).toBeInTheDocument()
   expect(screen.getByText('notice.title')).toBeInTheDocument()
   expect(screen.getByText('notice.description')).toBeInTheDocument()
-})
+}
+
+test(
+  'renders call to action with title, subcopy, and buttons',
+  rendersCallToActionWithTitleSubcopyAndButtons
+)

--- a/src/components/landing/call-to-action.tsx
+++ b/src/components/landing/call-to-action.tsx
@@ -13,6 +13,11 @@ import {
 import { AlertTriangle } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
+/**
+ * Displays the call-to-action section with primary and secondary links and a notice banner.
+ *
+ * @returns The call-to-action section of the landing page.
+ */
 export default function CallToAction() {
   const t = useTranslations('callToAction')
   const tHero = useTranslations('hero')

--- a/src/components/landing/code-examples.test.tsx
+++ b/src/components/landing/code-examples.test.tsx
@@ -36,7 +36,10 @@ Object.defineProperty(navigator, 'clipboard', {
 
 import { waitFor, within } from '@testing-library/react'
 
-test('renders code examples with title, subtitle, and tabs', async () => {
+/**
+ * Validates the code examples section renders localized content and supports copying snippets.
+ */
+async function rendersCodeExamplesWithTitleSubtitleAndTabs() {
   render(<CodeExamples />)
 
   expect(screen.getByText('codeExamples.title')).toBeInTheDocument()
@@ -70,4 +73,9 @@ test('renders code examples with title, subtitle, and tabs', async () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('viberetry code')
     expect(mockToast).toHaveBeenCalled()
   })
-})
+}
+
+test(
+  'renders code examples with title, subtitle, and tabs',
+  rendersCodeExamplesWithTitleSubtitleAndTabs
+)

--- a/src/components/landing/code-examples.tsx
+++ b/src/components/landing/code-examples.tsx
@@ -13,11 +13,22 @@ import { Button } from '../common/ui/button'
 import { useToast } from '@/hooks/use-toast'
 import { useTranslations } from 'next-intl'
 
+/**
+ * Presents copyable code samples for the landing page product suite.
+ *
+ * @returns The code examples section containing tabbed snippets.
+ */
 export default function CodeExamples() {
   const t = useTranslations('codeExamples')
   const { toast } = useToast()
   const [copied, setCopied] = useState<Record<string, boolean>>({})
 
+  /**
+   * Copies the provided code sample to the clipboard and shows success feedback.
+   *
+   * @param key - The identifier for the example being copied.
+   * @param text - The code to copy to the clipboard.
+   */
   const handleCopy = (key: string, text: string) => {
     navigator.clipboard.writeText(text)
     setCopied({ ...copied, [key]: true })

--- a/src/components/landing/confetti.test.tsx
+++ b/src/components/landing/confetti.test.tsx
@@ -5,7 +5,10 @@ import { ConfettiBackground } from '@/components/landing/confetti'
 
 vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
-test('renders confetti background with pieces', () => {
+/**
+ * Ensures the confetti background renders the expected number of uniformly styled pieces.
+ */
+function rendersConfettiBackgroundWithPieces() {
   const { container } = render(<ConfettiBackground />)
 
   const confettiPieces = container.querySelectorAll(
@@ -26,4 +29,6 @@ test('renders confetti background with pieces', () => {
       '--y': '0px',
     })
   })
-})
+}
+
+test('renders confetti background with pieces', rendersConfettiBackgroundWithPieces)

--- a/src/components/landing/confetti.tsx
+++ b/src/components/landing/confetti.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState, type CSSProperties } from 'react'
 
+/**
+ * Represents a single animated confetti piece rendered in the background.
+ */
 interface Piece {
   left: number
   top: number
@@ -14,6 +17,11 @@ interface Piece {
   y: number
 }
 
+/**
+ * Renders animated confetti squares used as a decorative background.
+ *
+ * @returns A positioned container with animated confetti spans.
+ */
 export function ConfettiBackground() {
   const [pieces, setPieces] = useState<Piece[]>([])
 

--- a/src/components/landing/faq.test.tsx
+++ b/src/components/landing/faq.test.tsx
@@ -14,7 +14,10 @@ vi.mock('@/lib/content', () => ({
 
 import { fireEvent } from '@testing-library/react'
 
-test('renders FAQ with title, subtitle, and accordion', () => {
+/**
+ * Ensures the FAQ renders localized questions and reveals answers on interaction.
+ */
+function rendersFaqWithTitleSubtitleAndAccordion() {
   render(<FAQ />)
 
   expect(screen.getByText('faq.title')).toBeInTheDocument()
@@ -33,4 +36,9 @@ test('renders FAQ with title, subtitle, and accordion', () => {
   // Click on the second question to reveal the answer
   fireEvent.click(screen.getByText('faq.q2.question'))
   expect(screen.getByText('faq.q2.answer')).toBeInTheDocument()
-})
+}
+
+test(
+  'renders FAQ with title, subtitle, and accordion',
+  rendersFaqWithTitleSubtitleAndAccordion
+)

--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -8,6 +8,11 @@ import {
 import { faqContent } from '@/lib/content'
 import { useTranslations } from 'next-intl'
 
+/**
+ * Renders the frequently asked questions section using localized copy.
+ *
+ * @returns The FAQ section of the landing page.
+ */
 export default function FAQ() {
   const t = useTranslations('faq')
   return (

--- a/src/components/landing/hero.test.tsx
+++ b/src/components/landing/hero.test.tsx
@@ -9,9 +9,9 @@ vi.mock('next-intl', () => ({
 }))
 
 vi.mock('next/image', () => ({
-  default: (props: any) => {
+  default: ({ alt = '', ...rest }: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />
+    return <img alt={alt} {...rest} />
   },
 }))
 
@@ -23,7 +23,10 @@ vi.mock('@/components/landing/confetti', () => ({
   ConfettiBackground: () => <div data-testid="confetti" />,
 }))
 
-test('renders hero with title, tagline, subcopy, and buttons', () => {
+/**
+ * Ensures the hero component renders core messaging and actions.
+ */
+function rendersHeroWithTitleTaglineSubcopyAndButtons() {
   render(<Hero />)
 
   expect(screen.getByText('siteConfig.name')).toBeInTheDocument()
@@ -32,4 +35,9 @@ test('renders hero with title, tagline, subcopy, and buttons', () => {
   expect(screen.getByText('hero.primaryCta')).toBeInTheDocument()
   expect(screen.getByText('hero.secondaryCta')).toBeInTheDocument()
   expect(screen.getByTestId('confetti')).toBeInTheDocument()
-})
+}
+
+test(
+  'renders hero with title, tagline, subcopy, and buttons',
+  rendersHeroWithTitleTaglineSubcopyAndButtons
+)

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -10,6 +10,11 @@ import { ConfettiBackground } from '@/components/landing/confetti'
 import { useTranslations } from 'next-intl'
 import { motion } from 'framer-motion'
 
+/**
+ * Renders the animated hero section with branding, messaging, and CTAs.
+ *
+ * @returns The hero section occupying the top of the landing page.
+ */
 export default function Hero() {
   const t = useTranslations('hero')
   const tSite = useTranslations('siteConfig')

--- a/src/components/landing/philosophy.test.tsx
+++ b/src/components/landing/philosophy.test.tsx
@@ -23,7 +23,10 @@ vi.mock('@/lib/content', () => ({
   },
 }))
 
-test('renders philosophy with title, subtitle, principles, and quote', () => {
+/**
+ * Verifies the philosophy section renders localized principles and the featured quote.
+ */
+function rendersPhilosophyWithTitleSubtitlePrinciplesAndQuote() {
   render(<Philosophy />)
 
   expect(screen.getByText('philosophy.title')).toBeInTheDocument()
@@ -42,4 +45,9 @@ test('renders philosophy with title, subtitle, principles, and quote', () => {
   ).toBeInTheDocument()
   expect(screen.getByText('"philosophy.quote"')).toBeInTheDocument()
   expect(screen.getByText('— philosophy.quoteAuthor')).toBeInTheDocument()
-})
+}
+
+test(
+  'renders philosophy with title, subtitle, principles, and quote',
+  rendersPhilosophyWithTitleSubtitlePrinciplesAndQuote
+)

--- a/src/components/landing/philosophy.tsx
+++ b/src/components/landing/philosophy.tsx
@@ -8,6 +8,11 @@ import {
 } from '@/components/common/ui/card'
 import { useTranslations } from 'next-intl'
 
+/**
+ * Highlights the guiding principles behind the product philosophy.
+ *
+ * @returns The philosophy section containing principle cards and a quote.
+ */
 export default function Philosophy() {
   const t = useTranslations('philosophy')
   return (

--- a/src/components/landing/tools-grid.test.tsx
+++ b/src/components/landing/tools-grid.test.tsx
@@ -40,7 +40,10 @@ vi.mock('@/navigation', () => ({
   Link: (props: any) => <a {...props} />,
 }))
 
-test('renders tools grid with title, subtitle, and tools', () => {
+/**
+ * Confirms the tools grid displays localized headings and tool cards.
+ */
+function rendersToolsGridWithTitleSubtitleAndTools() {
   render(<ToolsGrid />)
 
   expect(screen.getByText('tools.title')).toBeInTheDocument()
@@ -49,4 +52,9 @@ test('renders tools grid with title, subtitle, and tools', () => {
   expect(screen.getByText('tools.viberetry.name')).toBeInTheDocument()
   expect(screen.getByText('tools.vibegen.name')).toBeInTheDocument()
   expect(screen.getByText('tools.more')).toBeInTheDocument()
-})
+}
+
+test(
+  'renders tools grid with title, subtitle, and tools',
+  rendersToolsGridWithTitleSubtitleAndTools
+)

--- a/src/components/landing/tools-grid.tsx
+++ b/src/components/landing/tools-grid.tsx
@@ -13,6 +13,11 @@ import { Link } from '@/navigation'
 import { useTranslations } from 'next-intl'
 import { ThemedLogo } from '@/components/common/themed-logo'
 
+/**
+ * Showcases a curated selection of tools with descriptions and resource links.
+ *
+ * @returns The tools grid section of the landing page.
+ */
 export default function ToolsGrid() {
   const t = useTranslations('tools')
   const displayedTools = tools.filter((tool) =>

--- a/src/components/team/team-page.test.tsx
+++ b/src/components/team/team-page.test.tsx
@@ -3,8 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 vi.mock('next/image', () => ({
-  default: ({ fill: _fill, ...props }: any) => {
-    return <img {...props} />
+  default: ({ fill: _fill, alt = '', ...rest }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={alt} {...rest} />
   },
 }))
 
@@ -15,24 +16,22 @@ vi.mock('@/components/common/motion-section', () => ({
 }))
 
 vi.mock('framer-motion', () => {
+  const TeamCardMock = React.forwardRef<HTMLDivElement, any>(
+    (
+      { children, initial: _initial, animate: _animate, transition: _transition, ...props },
+      ref
+    ) => (
+      // eslint-disable-next-line @next/next/no-img-element
+      <div ref={ref} data-testid="team-card" {...props}>
+        {children}
+      </div>
+    )
+  )
+  TeamCardMock.displayName = 'TeamCardMock'
+
   return {
     motion: {
-      div: React.forwardRef<HTMLDivElement, any>(
-        (
-          {
-            children,
-            initial: _initial,
-            animate: _animate,
-            transition: _transition,
-            ...props
-          },
-          ref
-        ) => (
-          <div ref={ref} data-testid="team-card" {...props}>
-            {children}
-          </div>
-        )
-      ),
+      div: TeamCardMock,
     },
   }
 })
@@ -40,49 +39,67 @@ vi.mock('framer-motion', () => {
 import TeamPage from '@/components/team/team-page'
 import { teamMembers } from '@/lib/team'
 
+/**
+ * Verifies all team members render with their details.
+ */
+function rendersAllTeamMembersWithTheirRoles() {
+  render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
+
+  const cards = screen.getAllByTestId('team-card')
+  expect(cards).toHaveLength(teamMembers.length)
+
+  teamMembers.forEach((member) => {
+    expect(screen.getByText(member.name)).toBeInTheDocument()
+  })
+
+  expect(screen.getByText('Our Team')).toBeInTheDocument()
+  expect(screen.getByText('Meet the crew')).toBeInTheDocument()
+}
+
+/**
+ * Ensures touch interactions toggle the active member portrait state.
+ */
+function togglesTheActiveMemberWhenTappedOnTouchDevices() {
+  render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
+
+  const [firstCard] = screen.getAllByTestId('team-card')
+  const images = firstCard.querySelectorAll('img')
+  const colorImage = images[1] as HTMLImageElement
+
+  expect(colorImage.classList.contains('opacity-0')).toBe(true)
+  expect(colorImage.classList.contains('opacity-100')).toBe(false)
+
+  fireEvent.pointerDown(firstCard, { pointerType: 'touch' })
+  expect(colorImage.classList.contains('opacity-100')).toBe(true)
+  expect(colorImage.classList.contains('opacity-0')).toBe(false)
+
+  fireEvent.pointerDown(firstCard, { pointerType: 'touch' })
+  expect(colorImage.classList.contains('opacity-0')).toBe(true)
+  expect(colorImage.classList.contains('opacity-100')).toBe(false)
+}
+
+/**
+ * Confirms mouse interactions do not toggle the portrait state.
+ */
+function ignoresNonTouchPointerInteractions() {
+  render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
+
+  const [firstCard] = screen.getAllByTestId('team-card')
+  const images = firstCard.querySelectorAll('img')
+  const colorImage = images[1] as HTMLImageElement
+
+  fireEvent.pointerDown(firstCard, { pointerType: 'mouse' })
+  expect(colorImage.classList.contains('opacity-0')).toBe(true)
+  expect(colorImage.classList.contains('opacity-100')).toBe(false)
+}
+
 describe('TeamPage', () => {
-  test('renders all team members with their roles', () => {
-    render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
+  test('renders all team members with their roles', rendersAllTeamMembersWithTheirRoles)
 
-    const cards = screen.getAllByTestId('team-card')
-    expect(cards).toHaveLength(teamMembers.length)
+  test(
+    'toggles the active member when tapped on touch devices',
+    togglesTheActiveMemberWhenTappedOnTouchDevices
+  )
 
-    teamMembers.forEach((member) => {
-      expect(screen.getByText(member.name)).toBeInTheDocument()
-    })
-
-    expect(screen.getByText('Our Team')).toBeInTheDocument()
-    expect(screen.getByText('Meet the crew')).toBeInTheDocument()
-  })
-
-  test('toggles the active member when tapped on touch devices', () => {
-    render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
-
-    const [firstCard] = screen.getAllByTestId('team-card')
-    const images = firstCard.querySelectorAll('img')
-    const colorImage = images[1] as HTMLImageElement
-
-    expect(colorImage.classList.contains('opacity-0')).toBe(true)
-    expect(colorImage.classList.contains('opacity-100')).toBe(false)
-
-    fireEvent.pointerDown(firstCard, { pointerType: 'touch' })
-    expect(colorImage.classList.contains('opacity-100')).toBe(true)
-    expect(colorImage.classList.contains('opacity-0')).toBe(false)
-
-    fireEvent.pointerDown(firstCard, { pointerType: 'touch' })
-    expect(colorImage.classList.contains('opacity-0')).toBe(true)
-    expect(colorImage.classList.contains('opacity-100')).toBe(false)
-  })
-
-  test('ignores non-touch pointer interactions', () => {
-    render(<TeamPage title="Our Team" subtitle="Meet the crew" />)
-
-    const [firstCard] = screen.getAllByTestId('team-card')
-    const images = firstCard.querySelectorAll('img')
-    const colorImage = images[1] as HTMLImageElement
-
-    fireEvent.pointerDown(firstCard, { pointerType: 'mouse' })
-    expect(colorImage.classList.contains('opacity-0')).toBe(true)
-    expect(colorImage.classList.contains('opacity-100')).toBe(false)
-  })
+  test('ignores non-touch pointer interactions', ignoresNonTouchPointerInteractions)
 })

--- a/src/components/team/team-page.tsx
+++ b/src/components/team/team-page.tsx
@@ -7,16 +7,31 @@ import { teamMembers } from '@/lib/team'
 import MotionSection from '@/components/common/motion-section'
 import { cn } from '@/lib/utils'
 
+/**
+ * Props supplied to the team page component.
+ */
 interface TeamPageProps {
   title: string
   subtitle: string
 }
 
+/**
+ * Renders the team page highlighting members with animated portraits.
+ *
+ * @param props - The localized title and subtitle for the page.
+ * @returns The team showcase section.
+ */
 const TeamPage: FC<TeamPageProps> = ({ title, subtitle }) => {
   const [activeMemberIndex, setActiveMemberIndex] = useState<number | null>(
     null
   )
 
+  /**
+   * Toggles the active member when interacting via touch or pen input.
+   *
+   * @param index - The index of the team member being interacted with.
+   * @returns A pointer event handler that toggles the member state.
+   */
   const handleTouchToggle = useCallback(
     (index: number) => (event: PointerEvent<HTMLDivElement>) => {
       if (event.pointerType !== 'touch' && event.pointerType !== 'pen') {

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -27,6 +27,11 @@ const actionTypes = {
 
 let count = 0
 
+/**
+ * Generates a unique identifier for a toast entry, wrapping when the maximum safe integer is reached.
+ *
+ * @returns A string representation of the generated identifier.
+ */
 function genId() {
   count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
@@ -58,6 +63,11 @@ interface State {
 
 const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
 
+/**
+ * Schedules a toast for removal after the configured delay.
+ *
+ * @param toastId - The identifier of the toast to remove.
+ */
 const addToRemoveQueue = (toastId: string) => {
   if (toastTimeouts.has(toastId)) {
     return
@@ -74,6 +84,13 @@ const addToRemoveQueue = (toastId: string) => {
   toastTimeouts.set(toastId, timeout)
 }
 
+/**
+ * Reducer that manages the lifecycle of toast notifications.
+ *
+ * @param state - The current toast state.
+ * @param action - The dispatched action that mutates the state.
+ * @returns The updated state based on the action.
+ */
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'ADD_TOAST':
@@ -133,6 +150,11 @@ const listeners: Array<(state: State) => void> = []
 
 let memoryState: State = { toasts: [] }
 
+/**
+ * Broadcasts an action to the reducer and notifies subscribers of state changes.
+ *
+ * @param action - The toast action to dispatch.
+ */
 function dispatch(action: Action) {
   memoryState = reducer(memoryState, action)
   listeners.forEach((listener) => {
@@ -142,14 +164,29 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, 'id'>
 
+/**
+ * Creates a new toast and returns helpers to update or dismiss it.
+ *
+ * @param props - The toast configuration without an identifier.
+ * @returns Helpers to update or dismiss the toast.
+ */
 function toast({ ...props }: Toast) {
   const id = genId()
 
+  /**
+   * Applies partial updates to the toast referenced by this helper.
+   *
+   * @param props - The properties to merge into the toast.
+   */
   const update = (props: ToasterToast) =>
     dispatch({
       type: 'UPDATE_TOAST',
       toast: { ...props, id },
     })
+
+  /**
+   * Dismisses the toast associated with this helper.
+   */
   const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id })
 
   dispatch({
@@ -171,6 +208,11 @@ function toast({ ...props }: Toast) {
   }
 }
 
+/**
+ * React hook that exposes the current toasts along with helpers to manage them.
+ *
+ * @returns The toast state plus helper methods for showing and dismissing toasts.
+ */
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -4,6 +4,9 @@ import { getRequestConfig } from 'next-intl/server'
 // Can be imported from a shared config
 export const locales = ['en', 'zh']
 
+/**
+ * Configures next-intl to load locale-specific translations and handle unknown locales.
+ */
 export default getRequestConfig(async ({ locale }) => {
   const lng = locale ?? 'en'
   if (!locales.includes(lng)) notFound()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,10 +2,21 @@ import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import type { MouseEvent as ReactMouseEvent } from 'react'
 
+/**
+ * Concatenates and merges Tailwind class names while removing duplicates.
+ *
+ * @param inputs - A list of class name values that can include strings, arrays, or conditionals.
+ * @returns A single Tailwind-safe class string.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Handles smooth scrolling to anchor targets and locale-aware home navigation for header/footer links.
+ *
+ * @param event - The anchor click event whose default navigation might be prevented.
+ */
 export function scrollToSection(event: ReactMouseEvent<HTMLAnchorElement>) {
   const href = event.currentTarget.getAttribute('href')
 

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,6 +1,9 @@
 import { createNavigation } from 'next-intl/navigation'
 import { locales } from './i18n/request'
 
+/**
+ * Provides typed navigation helpers that are aware of the locales supported by the app.
+ */
 export const { Link, redirect, usePathname, useRouter } = createNavigation({
   locales,
 })


### PR DESCRIPTION
## Summary
- add comprehensive JSDoc comments to app pages, components, and utilities for clearer intent
- refactor tests to use documented helper functions so suite-level behavior remains easy to follow
- tighten linting by enabling eslint-plugin-jsdoc to require docstrings across the codebase

## Testing
- npm run lint
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfd5b736108327b1a523829a23250f